### PR TITLE
Fix module home routes

### DIFF
--- a/example/lib/modules/first_module.dart
+++ b/example/lib/modules/first_module.dart
@@ -1,7 +1,6 @@
 import 'package:example/bloc/first_module/first_module_bloc.dart';
 import 'package:example/views/first_module/first_module_view.dart';
 import 'package:moduler_route/moduler_route.dart';
-import 'package:page_transition/page_transition.dart';
 
 final String _modulePath = "first-module";
 

--- a/lib/src/moduler.dart
+++ b/lib/src/moduler.dart
@@ -6,7 +6,6 @@ import 'dart:io' show Platform;
 
 import 'injector.dart';
 import 'module.dart';
-import 'module_route.dart';
 import 'route_transiction_type.dart';
 import 'unknown_route.dart';
 
@@ -33,7 +32,7 @@ mixin Moduler {
       modulePath = fullPath[0];
 
       fullPath.removeAt(0);
-      
+
       routePath = fullPath.join('/');
 
       if (routePath?.isEmpty != false) {
@@ -48,7 +47,14 @@ mixin Moduler {
     }
 
     if (module == null) {
-      module = _currentModule.module;
+      modulePath = fullPath[0];
+
+      if (modules?.any((module) => module?.path == modulePath) == true) {
+        module = modules?.firstWhere(
+          (module) => module?.path == modulePath,
+        );
+      }
+
       routePath = routeSettings.name;
     }
 
@@ -73,7 +79,7 @@ mixin Moduler {
     final route = module?.routes?.firstWhere(
       (route) => route.path == routePath,
       orElse: () {
-        return _currentModule.module.routes.firstWhere(
+        return module?.routes?.firstWhere(
             (route) => route.path == "/" || route.path == "",
             orElse: () => null);
       },

--- a/lib/src/moduler.dart
+++ b/lib/src/moduler.dart
@@ -33,7 +33,7 @@ mixin Moduler {
       modulePath = fullPath[0];
 
       fullPath.removeAt(0);
-
+      
       routePath = fullPath.join('/');
 
       if (routePath?.isEmpty != false) {
@@ -44,20 +44,6 @@ mixin Moduler {
         module = modules?.firstWhere(
           (module) => module?.path == modulePath,
         );
-      }
-    }
-
-    if (module == null) {
-      ModuleRoute route;
-
-      if (_currentModule.hasModule) {
-        route = _currentModule.module.routes.firstWhere(
-          (route) => route.path == routeSettings.name,
-        );
-      }
-
-      if (route == null) {
-        return _pageRoute(UnknownRoute(), null);
       }
     }
 
@@ -86,6 +72,11 @@ mixin Moduler {
 
     final route = module?.routes?.firstWhere(
       (route) => route.path == routePath,
+      orElse: () {
+        return _currentModule.module.routes.firstWhere(
+            (route) => route.path == "/" || route.path == "",
+            orElse: () => null);
+      },
     );
 
     if (route == null) {


### PR DESCRIPTION
This is a fix for #1 . Now you can use "/" or "" as the home route of each module. It will get the first route with any of those configs to use as home.